### PR TITLE
Fix crash when requiring REXML

### DIFF
--- a/lib/laser/analysis/sexp.rb
+++ b/lib/laser/analysis/sexp.rb
@@ -98,14 +98,18 @@ module Laser
       # Performs a DFS on the node, yielding each subnode (including the given node)
       # in DFS order.
       def dfs
-        yield self
-        self.children.each do |child|
-          next unless is_sexp?(child)
-          case child[0]
-          when Array
-            child.each { |x| x.dfs { |y| yield y}}
-          when ::Symbol
-            child.dfs { |y| yield y }
+        stack = [self]
+        while node = stack.pop
+          yield node
+
+          node.children.reverse.each do |child|
+            next unless is_sexp?(child)
+            case child[0]
+            when Array
+              child.reverse.each { |x| stack.push(x) }
+            when ::Symbol
+              stack.push(child)
+            end
           end
         end
       end

--- a/lib/laser/analysis/sexp_extensions/constant_extraction.rb
+++ b/lib/laser/analysis/sexp_extensions/constant_extraction.rb
@@ -45,9 +45,11 @@ module Laser::Analysis
           str = self[1]
           pos = self.parent.parent.source_begin
           first_two = lines[pos[0]-1][pos[1],2]
-          if first_two[0,1] == '"' || first_two == '%Q'
+          if first_two[0,1] == '"'
             eval(%Q{"#{str}"})
-          else   
+          elsif first_two == '%Q'
+            eval("%Q{#{str}}")
+          else
             str
           end
         when :string_content

--- a/lib/laser/runner.rb
+++ b/lib/laser/runner.rb
@@ -75,7 +75,7 @@ module Laser
         opt :stdin, 'Read Ruby code from standard input', short: '-s'
         opt :'list-modules', 'Print the discovered, loaded modules'
         opt :profile, 'Run the profiler during execution'
-        opt :include, 'specify $LOAD_PATH directory (may be used more than once)', short: '-I', multi: true#, type: :string
+        opt :include, 'specify $LOAD_PATH directory (may be used more than once)', short: '-I', multi: true, type: :string
         opt :S, 'look for scripts using PATH environment variable', short: '-S'
         warning_opts.each { |warning| opt(*warning) }
       end

--- a/lib/laser/runner.rb
+++ b/lib/laser/runner.rb
@@ -75,7 +75,7 @@ module Laser
         opt :stdin, 'Read Ruby code from standard input', short: '-s'
         opt :'list-modules', 'Print the discovered, loaded modules'
         opt :profile, 'Run the profiler during execution'
-        opt :include, 'specify $LOAD_PATH directory (may be used more than once)', short: '-I', multi: true
+        opt :include, 'specify $LOAD_PATH directory (may be used more than once)', short: '-I', multi: true#, type: :string
         opt :S, 'look for scripts using PATH environment variable', short: '-S'
         warning_opts.each { |warning| opt(*warning) }
       end

--- a/spec/analysis_specs/sexp_extension_specs/constant_extraction_spec.rb
+++ b/spec/analysis_specs/sexp_extension_specs/constant_extraction_spec.rb
@@ -93,6 +93,14 @@ describe Sexp do
         list[0][2].is_constant.should be true
         list[0][2].constant_value.should == 'abc \n \x12def'
       end
+
+      it 'should not be fooled by quotes inside %Q{}' do
+        input = 'a = %Q{"}'
+        tree = annotate_all(input)
+        list = tree[1]
+        list[0][2].is_constant.should be true
+        list[0][2].constant_value.should == '"'
+      end
     end
 
     describe 'handling integer literals' do

--- a/spec/runner_spec.rb
+++ b/spec/runner_spec.rb
@@ -141,6 +141,12 @@ describe Runner do
       settings[:"report-fixed"].should be_true
       settings[:"report-fixed_given"].should be_true
     end
+
+    it 'has a --include option' do
+      runner = Runner.new(['--include=/some/path', '-I', '/another/path'])
+      settings = runner.swizzling_argv { runner.get_settings }
+      settings[:include].should == ["/some/path", "/another/path"]
+    end
   end
 
   describe '#handle_global_options' do


### PR DESCRIPTION
ConstantExtraction.constant_value was attempting to
evaluate """, which threw a syntax error.  Changed
it to eval %Q{} or "" depending on what the code under
analysis uses.
